### PR TITLE
Use pull_request_target event to run CI against the base repo.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ name: Test
 on:
   push:
     branches: [ main, develop ]
-  pull_request:
+  pull_request_target:
     branches: [ main, develop ]
 
 jobs:


### PR DESCRIPTION
> we’ve added a new pull_request_target event, which behaves in an
> almost identical way to the pull_request event with the same set of
> filters and payload. However, instead of running against the workflow
> and code from the merge commit, the event runs against the workflow and
> code from the base of the pull request. This means the workflow is
> running from a trusted source and is given access to a read/write token
> as well as secrets

This should fix the error of a missing CC_TEST_REPORTER_ID when running
on PRS from forked repos.