### PR TITLE
Add explicit PR checkout for a pull request when running CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      # Please refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+      # for issues this can cause. We mitigate it with requiring a tag to be set. Which only maintainers can add.
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This ensures we run the CI using the code as provided in the PR.
This code is insecure and not controlled by us. So we require an
additional tag to be set on the PR before running this: requiring manual
check by a maintainer.